### PR TITLE
Update README.md - comando admin no windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ Windows - abrir o nodepad como administrador
 ```
 C:\Windows\System32\drivers\etc\hosts
 ```
+```
+Start-Process notepad -Argument C:\Windows\System32\drivers\etc\hosts -Verb RunAs
+```
 
 Linux e Mac - editar usando sudo
 ```


### PR DESCRIPTION
Adicionado comando único para abrir o arquivo /etc/hosts no windows como admin